### PR TITLE
SOE-3671: Fixing the chrome play bug in js and css

### DIFF
--- a/css/stanford_paragraph_types.p_featured.css
+++ b/css/stanford_paragraph_types.p_featured.css
@@ -8,6 +8,10 @@
   padding: 0;
 }
 
+.paragraphs-item-p-featured.has-image.has-video .field-name-field-p-featured-video {
+  display: none;
+}
+
 .paragraphs-item-p-featured > .content {
   position: relative;
 }
@@ -75,10 +79,6 @@
 
 .paragraphs-item-p-featured a.play-video i:before {
   font-size: 140px;
-}
-
-.paragraphs-item-p-featured .field-name-field-p-featured-video {
-  display: none;
 }
 
 @media (max-width: 767px) {

--- a/css/stanford_paragraph_types.p_featured.css
+++ b/css/stanford_paragraph_types.p_featured.css
@@ -77,7 +77,7 @@
   font-size: 140px;
 }
 
-.paragraphs-item-p-featured .field-name-field-p-featured-video:nth-child(2) {
+.paragraphs-item-p-featured .field-name-field-p-featured-video {
   display: none;
 }
 

--- a/js/stanford_paragraph_types.p_featured.js
+++ b/js/stanford_paragraph_types.p_featured.js
@@ -4,7 +4,7 @@
  */
 
 (function ($) {
-  Drupal.behaviors.stanfordParagraphPHero = {
+  Drupal.behaviors.stanfordParagraphPFeatured = {
 
     attach: function (context, settings) {
 
@@ -24,7 +24,7 @@
       // If there is a vimeo video add the player api script.
       if ($('.field-name-field-p-featured-video iframe[src*="vimeo"]', context).length) {
         $.getScript('https://player.vimeo.com/api/player.js', function () {
-          Drupal.behaviors.stanfordParagraphPHero.vimeoReady();
+          Drupal.behaviors.stanfordParagraphPFeatured.vimeoReady();
         });
       }
     },
@@ -72,7 +72,7 @@
         $fieldWrapper = $(event.target.a.closest('.field-name-field-p-featured-video'));
         $imageOverlay = $fieldWrapper.siblings('.field-name-field-p-featured-image');
 
-        var $play = Drupal.behaviors.stanfordParagraphPHero.getPlayerButton(event.target.getVideoUrl());
+        var $play = Drupal.behaviors.stanfordParagraphPFeatured.getPlayerButton(event.target.getVideoUrl());
 
         // Add a click event to hide the featured image and play the video.
         $play.click(function (e) {
@@ -107,7 +107,7 @@
         $fieldWrapper = $($(iframe).closest('.field-name-field-p-featured-video'));
         $imageOverlay = $fieldWrapper.siblings('.field-name-field-p-featured-image');
 
-        var $play = Drupal.behaviors.stanfordParagraphPHero.getPlayerButton($(iframe).attr('src'));
+        var $play = Drupal.behaviors.stanfordParagraphPFeatured.getPlayerButton($(iframe).attr('src'));
 
         $play.click(function (e) {
           // Mouse has eventPhase 3, keyboard has 2. we only add the mouse
@@ -119,6 +119,7 @@
             // Dad is the featured image.
             $dad = $(this).parent();
             $dad.hide();
+            $dad.siblings('.group-overlay-text').hide();
 
             // Show and play the video.
             $fieldWrapper.show();
@@ -160,5 +161,5 @@
  */
 function onYouTubeIframeAPIReady() {
   // After Youtube API is loaded, we can do what we need.
-  Drupal.behaviors.stanfordParagraphPHero.youTubeReady();
+  Drupal.behaviors.stanfordParagraphPFeatured.youTubeReady();
 }

--- a/js/stanford_paragraph_types.p_featured.js
+++ b/js/stanford_paragraph_types.p_featured.js
@@ -4,48 +4,162 @@
  */
 
 (function ($) {
-  Drupal.behaviors.stanfordParagraphPFeatured = {
+  Drupal.behaviors.stanfordParagraphPHero = {
+
     attach: function (context, settings) {
-      $('.field-name-field-p-featured-image', context).each(function () {
-        var video = $(this).siblings('.field-name-field-p-featured-video');
 
-        if (video.length) {
-          $(video).find('iframe').attr('title', Drupal.t('Video Player'));
-          var videoUrl = $(video).find('div[data-video-embed-url]').attr('data-video-embed-url');
-
-          var play = $('<a>', {
-            class: 'play-video',
-            href: videoUrl,
-            html: $('<i>', {
-              class: 'fa fa-youtube-play icon-youtube-play',
-              html: '',
-              'aria-label': Drupal.t('Play Video - Opens to the video website')
-            })
-          }).click(function (e) {
-
-            // Mouse has eventPhase 3, keyboard has 2.
-            if (e.eventPhase == 3) {
-              e.preventDefault();
-              $dad = $(this).parent();
-
-              // Push the image overlay behind the video
-              $dad.css('z-index', 1);
-
-              var iframe = $(video).find('iframe')[0];
-
-              iframe.src += "&autoplay=1";
-              $(iframe).attr('onload', 'this.contentWindow.focus()');
-
-              // We need to change to absolute for correct style
-              $(video).css('position', 'absolute');
-              $(video).show();
-            }
-
-          });
-
-          $(this).prepend(play);
+      // Loop through each featured video fields and add a unique ID.
+      $('.field-name-field-p-featured-video iframe', context).each(function (i, iframe) {
+        // Make sure the video has an ID attribute.
+        if (typeof $(iframe).attr('id') == 'undefined') {
+          $(this).attr('id', 'featured-video-' + i);
         }
       });
+
+      // If there is a youtube player, add the player api script.
+      if ($('.field-name-field-p-featured-video iframe[src*="youtube"]', context).length) {
+        $.getScript('https://www.youtube.com/iframe_api');
+      }
+
+      // If there is a vimeo video add the player api script.
+      if ($('.field-name-field-p-featured-video iframe[src*="vimeo"]', context).length) {
+        $.getScript('https://player.vimeo.com/api/player.js', function () {
+          Drupal.behaviors.stanfordParagraphPHero.vimeoReady();
+        });
+      }
+    },
+
+    /**
+     * Called after YouTubes API is ready and adds event reactions to videos.
+     */
+    youTubeReady: function () {
+      // For each of the featured images, but only once, add onload/onready events
+      // to its sibling video player.
+      $('.field-name-field-p-featured-image').once('youtube', function (i, featuredImage) {
+
+        // Look for a featured video.
+        var $video = $(featuredImage).siblings('.field-name-field-p-featured-video').find('iframe[src*="youtube"]');
+
+        // End if none. The user might have only wanted an image, or it might
+        // be a vimeo video.
+        if (!$video.length) {
+          return;
+        }
+
+        // On each of the video elements attach an onReady event and set the
+        // title for accessibility reasons.
+        $video.attr('onload', 'this.contentWindow.focus()')
+          .attr('title', Drupal.t('Video Player'));
+
+        // Initialze the Youtube api.
+        new YT.Player($video.attr('id'), {
+          events: {
+            'onReady': onYoutubePlayerReady
+          }
+        });
+        // Force the iframe to allow the api event listeners.
+        $video.attr('src', $video.attr('src') + '&enablejsapi=1');
+      });
+
+
+      /**
+       * When the youtube video is ready to play, we'll add a play button over
+       * the image and add the click listener.
+       *
+       * @param event
+       */
+      function onYoutubePlayerReady(event) {
+        $fieldWrapper = $(event.target.a.closest('.field-name-field-p-featured-video'));
+        $imageOverlay = $fieldWrapper.siblings('.field-name-field-p-featured-image');
+
+        var $play = Drupal.behaviors.stanfordParagraphPHero.getPlayerButton(event.target.getVideoUrl());
+
+        // Add a click event to hide the featured image and play the video.
+        $play.click(function (e) {
+          // Mouse has eventPhase 3, keyboard has 2. we only add the mouse
+          // event so that a keyboard will navigate the user to the respective
+          // YouTube page.
+          if (e.eventPhase == 3) {
+            e.preventDefault();
+
+            // Dad is the featured image.
+            $dad = $(this).parent();
+            $dad.hide();
+
+            // Play and show the video.
+            $fieldWrapper.show();
+            event.target.playVideo();
+          }
+        });
+
+        // Prepend the play button to the DOM.
+        $imageOverlay.prepend($play);
+      }
+    },
+
+    /**
+     * After vimeo API is loaded, add the play button and listener to iframes.
+     */
+    vimeoReady: function () {
+      $('.field-name-field-p-featured-video iframe[src*="vimeo"]').each(function (i, iframe) {
+        var player = new Vimeo.Player($(iframe));
+
+        $fieldWrapper = $($(iframe).closest('.field-name-field-p-featured-video'));
+        $imageOverlay = $fieldWrapper.siblings('.field-name-field-p-featured-image');
+
+        var $play = Drupal.behaviors.stanfordParagraphPHero.getPlayerButton($(iframe).attr('src'));
+
+        $play.click(function (e) {
+          // Mouse has eventPhase 3, keyboard has 2. we only add the mouse
+          // event so that a keyboard will navigate the user to the respective
+          // Vimeo page.
+          if (e.eventPhase == 3) {
+            e.preventDefault();
+
+            // Dad is the featured image.
+            $dad = $(this).parent();
+            $dad.hide();
+            $dad.siblings('.group-overlay-text').hide();
+
+            // Show and play the video.
+            $fieldWrapper.show();
+            player.play();
+          }
+        });
+
+        // Prepend the play button to the DOM.
+        $imageOverlay.prepend($play);
+      });
+    },
+
+    /**
+     * Get a generic play button link.
+     *
+     * @param hrefUrl
+     *   The url of the given video iframe.
+     * @returns {*|HTMLElement}
+     *   The A tag element.
+     */
+    getPlayerButton: function (hrefUrl) {
+      return $('<a>', {
+        class: 'play-video',
+        href: hrefUrl,
+        title: Drupal.t('Play Video'),
+        html: $('<i>', {
+          class: 'fa fa-youtube-play icon-youtube-play',
+          html: 'Play Video',
+          'aria-label': Drupal.t('Play Video - Opens to the video website')
+        })
+      });
     }
+
   }
 })(jQuery);
+
+/**
+ * Called automatically by YouTube's API.
+ */
+function onYouTubeIframeAPIReady() {
+  // After Youtube API is loaded, we can do what we need.
+  Drupal.behaviors.stanfordParagraphPHero.youTubeReady();
+}

--- a/js/stanford_paragraph_types.p_featured.js
+++ b/js/stanford_paragraph_types.p_featured.js
@@ -8,6 +8,7 @@
 
     attach: function (context, settings) {
 
+
       // Loop through each featured video fields and add a unique ID.
       $('.field-name-field-p-featured-video iframe', context).each(function (i, iframe) {
         // Make sure the video has an ID attribute.
@@ -15,11 +16,6 @@
           $(this).attr('id', 'featured-video-' + i);
         }
       });
-
-      // If there is a youtube player, add the player api script.
-      if ($('.field-name-field-p-featured-video iframe[src*="youtube"]', context).length) {
-        $.getScript('https://www.youtube.com/iframe_api');
-      }
 
       // If there is a vimeo video add the player api script.
       if ($('.field-name-field-p-featured-video iframe[src*="vimeo"]', context).length) {
@@ -46,56 +42,84 @@
           return;
         }
 
-        // On each of the video elements attach an onReady event and set the
-        // title for accessibility reasons.
-        $video.attr('onload', 'this.contentWindow.focus()')
-          .attr('title', Drupal.t('Video Player'));
+        // Get Video Id and Attributes
+        var $videoSource = $video.attr('src');
+        var $srcParts = $videoSource.split('/');
+        var $videoInfo  = $srcParts[4].split('?');
+        var $videoId = $videoInfo[0];
 
-        // Initialze the Youtube api.
-        new YT.Player($video.attr('id'), {
+        //Get video attributes
+        var $videoAttr = decodeURIComponent($videoInfo[1]);
+        $videoAttr = $videoAttr.replace(/&amp;/g, '&');
+
+        // Helper function to get paramaters from iframe attributes
+        function getUrlParameter(name) {
+          name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+          var regex = new RegExp('(&amp;|)' + name + '=([^&#]*)', 'i' );
+          var results = regex.exec($videoAttr);
+          return results === null ? '' : results[0].replace(/\+/g, ' ');
+        };
+
+        // Get the width of the video
+        $videoWidthParts = getUrlParameter('width');
+        $videoWidthParts = $videoWidthParts.split('=');
+        $videoWidth = $videoWidthParts[1];
+
+        // Get the height of the video
+        $videoHeightParts = getUrlParameter('height');
+        $videoHeightParts = $videoHeightParts.split('=');
+        $videoHeight = $videoHeightParts[1];
+
+        $video.parent().attr('id', 'featured-video-' + i);
+        $video.remove();
+
+        var player = new YT.Player('featured-video-' + i, {
+          height: $videoHeight,
+          width: $videoWidth,
+          videoId: $videoId,
           events: {
-            'onReady': onYoutubePlayerReady
-          }
+            'onReady': Drupal.behaviors.stanfordParagraphPFeatured.onYoutubePlayerReady
+          },
+          host: 'https://www.youtube.com'
         });
-        // Force the iframe to allow the api event listeners.
-        $video.attr('src', $video.attr('src') + '&enablejsapi=1');
       });
 
-
-      /**
-       * When the youtube video is ready to play, we'll add a play button over
-       * the image and add the click listener.
-       *
-       * @param event
-       */
-      function onYoutubePlayerReady(event) {
-        $fieldWrapper = $(event.target.a.closest('.field-name-field-p-featured-video'));
-        $imageOverlay = $fieldWrapper.siblings('.field-name-field-p-featured-image');
-
-        var $play = Drupal.behaviors.stanfordParagraphPFeatured.getPlayerButton(event.target.getVideoUrl());
-
-        // Add a click event to hide the featured image and play the video.
-        $play.click(function (e) {
-          // Mouse has eventPhase 3, keyboard has 2. we only add the mouse
-          // event so that a keyboard will navigate the user to the respective
-          // YouTube page.
-          if (e.eventPhase == 3) {
-            e.preventDefault();
-
-            // Dad is the featured image.
-            $dad = $(this).parent();
-            $dad.hide();
-
-            // Play and show the video.
-            $fieldWrapper.show();
-            event.target.playVideo();
-          }
-        });
-
-        // Prepend the play button to the DOM.
-        $imageOverlay.prepend($play);
-      }
     },
+
+    /**
+     * When the youtube video is ready to play, we'll add a play button over
+     * the image and add the click listener.
+     *
+     * @param event
+     */
+    onYoutubePlayerReady: function (event) {
+
+      $fieldWrapper = $(event.target.a.closest('.field-name-field-p-featured-video'));
+      $imageOverlay = $fieldWrapper.siblings('.field-name-field-p-featured-image');
+
+      var $play = Drupal.behaviors.stanfordParagraphPFeatured.getPlayerButton(event.target.getVideoUrl());
+      // Add a click event to hide the featured image and play the video.
+      $play.click(function (e) {
+        // Mouse has eventPhase 3, keyboard has 2. we only add the mouse
+        // event so that a keyboard will navigate the user to the respective
+        // YouTube page.
+        if (e.eventPhase == 3) {
+          e.preventDefault();
+
+          // Dad is the featured image.
+          $dad = $(this).parent();
+          $dad.hide();
+
+          // Play and show the video.
+          $fieldWrapper.show();
+          event.target.playVideo();
+        }
+      });
+
+      // Prepend the play button to the DOM.
+      $imageOverlay.prepend($play);
+    },
+
 
     /**
      * After vimeo API is loaded, add the play button and listener to iframes.
@@ -157,9 +181,25 @@
 })(jQuery);
 
 /**
- * Called automatically by YouTube's API.
+ * Custom Event Listener for an Event in SOE Google Tag Manager
+ * https://tagmanager.google.com
+ * Use swsdevelopers@gmail.com to login
+ * The GTM tag with the referenced event 'dpTrigger' is in: Listener YouTube Tag
+ * Code Section:
+ * // Create the event for Paragraph Videos
+ * var dpYTReady = document.createEvent('Event');
+ * // Define that the event name is 'dpTrigger'.
+ * dpYTReady.initEvent('dpTrigger', true, true);
+ * // Dispatch the event
+ * document.dispatchEvent(dpYTReady);
  */
-function onYouTubeIframeAPIReady() {
-  // After Youtube API is loaded, we can do what we need.
-  Drupal.behaviors.stanfordParagraphPFeatured.youTubeReady();
-}
+document.addEventListener('dpTrigger', function () {
+  function readyYoutube(){
+    if((typeof YT !== "undefined") && YT && YT.Player){
+      Drupal.behaviors.stanfordParagraphPFeatured.youTubeReady();
+    }else{
+      setTimeout(readyYoutube, 100);
+    }
+  }
+  readyYoutube();
+});

--- a/js/stanford_paragraph_types.p_featured.js
+++ b/js/stanford_paragraph_types.p_featured.js
@@ -119,7 +119,6 @@
             // Dad is the featured image.
             $dad = $(this).parent();
             $dad.hide();
-            $dad.siblings('.group-overlay-text').hide();
 
             // Show and play the video.
             $fieldWrapper.show();

--- a/scss/stanford_paragraph_types.p_featured.scss
+++ b/scss/stanford_paragraph_types.p_featured.scss
@@ -79,7 +79,7 @@
     }
   }
 
-  .field-name-field-p-featured-video:nth-child(2) {
+  .field-name-field-p-featured-video {
     display: none;
   }
 

--- a/scss/stanford_paragraph_types.p_featured.scss
+++ b/scss/stanford_paragraph_types.p_featured.scss
@@ -9,6 +9,13 @@
 }
 
 .paragraphs-item-p-featured {
+
+  &.has-image.has-video {
+    .field-name-field-p-featured-video {
+      display: none;
+    }
+  }
+
   > .content {
     position: relative;
 
@@ -77,10 +84,6 @@
     i:before {
       font-size: 140px;
     }
-  }
-
-  .field-name-field-p-featured-video {
-    display: none;
   }
 
   @media (max-width: 767px) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SOE Featured paragraph type

# Needed By (Date)
- Sprint end

# Criticality
- Client is eagerly awaiting this for the release.

# Steps to Test
- **there is a known bug where if there are two featured video blocks with image overlay, things get wonky when you play one then the other. Don't worry about that right now.**
- open the page `catalog-patterns/blocks-and-beans/featured-content-blocks` in chrome first.
- notice how the video does not play until you hit the play button a second time.
- checkout branch `SOE-3671`
- `drush cc css-js`
- clear your browsers cache
- now reload that page and it should work now.

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-3671

## Related PRs

## More Information

## Folks to notify
@boznik 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)